### PR TITLE
chore: Skip BrickLoader test

### DIFF
--- a/tests/unit/Bricks/LoadBricksTest.php
+++ b/tests/unit/Bricks/LoadBricksTest.php
@@ -72,7 +72,12 @@ class LoadBricksTest extends TestCase
 
     public function testItLoadBrick(): void
     {
-        $loader = new LoadBricks();
+        /**
+         * @see https://github.com/composer/composer/issues/12235
+         */
+        self::markTestSkipped('This test does not pass since composer 2.8.4');
+
+        $loader = new LoadBricks(); // @phpstan-ignore deadCode.unreachable
         $bricks = $loader->loadInstalledBricks();
 
         self::assertCount(2, $bricks);


### PR DESCRIPTION
Closes #96

Since composer 2.8.4, InstalledVersions::reload doesn't work.

See https://github.com/composer/composer/issues/12235